### PR TITLE
Enhance AESA radar behaviour

### DIFF
--- a/RadarMain/Engine/SimulationEngine.cs
+++ b/RadarMain/Engine/SimulationEngine.cs
@@ -363,10 +363,12 @@ namespace RealRadarSim.Engine
                             bestTgt = t;
                         }
                     }
-                    if (bestTgt != null && bestDist < 5000)
-                        trk.FlightName = bestTgt.AircraftName;
-                }
+                if (bestTgt != null && bestDist < 5000)
+                    trk.FlightName = bestTgt.AircraftName;
             }
+
+            Radar.UpdateTrackAssignments(tracks);
+        }
         }
 
         public double GetDt() => dt;

--- a/RadarMain/Forms/RadarForm.cs
+++ b/RadarMain/Forms/RadarForm.cs
@@ -275,6 +275,27 @@ namespace RealRadarSim.Forms
                                 startAngle, sweepAngle);
                         }
                     }
+                    if (advRadar.LockBeam != null && advRadar.LockBeam.IsTracking)
+                    {
+                        double az = advRadar.LockBeam.CurrentAzimuth;
+                        double bw = radar.BeamWidthRad;
+                        float startAngle = (float)((az - bw / 2.0) * 180.0 / Math.PI);
+                        float sweepAngle = (float)(bw * 180.0 / Math.PI);
+                        using (Brush lockBrush = new SolidBrush(Color.FromArgb(120, Color.Red)))
+                        {
+                            g.FillPie(lockBrush,
+                                -radarDisplayRadius, -radarDisplayRadius,
+                                radarDisplayRadius * 2, radarDisplayRadius * 2,
+                                startAngle, sweepAngle);
+                        }
+                        using (Pen lockPen = new Pen(Color.Red, 2))
+                        {
+                            g.DrawPie(lockPen,
+                                -radarDisplayRadius, -radarDisplayRadius,
+                                radarDisplayRadius * 2, radarDisplayRadius * 2,
+                                startAngle, sweepAngle);
+                        }
+                    }
                     // Draw max azimuth text (fixed at 70°).
                     g.ResetTransform();
                     g.DrawString("Radar Max Azimuth: 70°", trackFont, textBrush, 20, 20);


### PR DESCRIPTION
## Summary
- add dedicated AESA lock beam with track assignment
- update beam updating logic to handle search and lock beams
- visualize locked AESA beam in RadarForm
- allocate lock beam based on track probabilities

## Testing
- `dotnet build RadarSimCs.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f3e3060bc8324a25d8c4ec86a207c