### PR TITLE
Add Fox-1 missile simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # What it contains? 
-The simulation right now contains Extended Kalman Filter, JPDA Filter, CFAR Algorithm, basic AESA, and DBSCAN.
+The simulation right now contains Extended Kalman Filter, JPDA Filter, CFAR Algorithm, basic AESA, DBSCAN, and a simple Fox‑1 missile model.
 Configuration can now be supplied via **config.json** for easier tweaking.
 
 # What are planned updates?
 I plan to introduce scripting engine so you can write your own Kalman Filters with ease.
 JSON configuration support is an initial step towards cleaner extensibility.
+
+## Controls
+* Click on a track to lock it with the radar.
+* Press **M** to fire a Fox‑1 missile at the locked target.
+* Press **U** to unlock the radar.
 
 # What's the point?
 Simulation point is to properly simulate a radar.

--- a/RadarMain/Forms/RadarForm.cs
+++ b/RadarMain/Forms/RadarForm.cs
@@ -203,6 +203,10 @@ namespace RealRadarSim.Forms
                 radar.UnlockTarget();
                 Console.WriteLine("[RadarForm] Radar unlocked (bar-scan resumed).");
             }
+            else if (e.KeyCode == Keys.M)
+            {
+                engine.LaunchMissile();
+            }
 
             this.Invalidate();
         }
@@ -453,6 +457,15 @@ namespace RealRadarSim.Forms
                 {
                     g.DrawEllipse(highlightPen, hx - 10, hy - 10, 20, 20);
                 }
+            }
+
+            // Draw launched missiles
+            var missiles = engine.GetMissiles();
+            foreach (var m in missiles)
+            {
+                int mx = (int)(m.Pos[0] * scale);
+                int my = (int)(m.Pos[1] * scale);
+                g.FillEllipse(Brushes.Orange, mx - 4, my - 4, 8, 8);
             }
 
             var targetsList = engine.GetTargets();

--- a/RadarMain/Missile/Fox1Missile.cs
+++ b/RadarMain/Missile/Fox1Missile.cs
@@ -1,0 +1,96 @@
+using System;
+using MathNet.Numerics.LinearAlgebra;
+using MathNet.Numerics.LinearAlgebra.Double;
+using RealRadarSim.Tracking;
+
+namespace RealRadarSim.Missile
+{
+    /// <summary>
+    /// Very simple missile model using proportional navigation guidance.
+    /// This is meant for ground launched Fox‑1 (semi active) missiles.
+    /// The state is [position, velocity]. The missile has a limited burn time
+    /// and a crude drag model. Gravity is accounted for.
+    /// </summary>
+    public class Fox1Missile
+    {
+        public Vector<double> Pos;  // [x,y,z] in meters
+        public Vector<double> Vel;  // [vx,vy,vz] in m/s
+        public bool Active => lifeTime < maxLifeTime && Pos[2] > 0;
+        public bool HitTarget { get; private set; } = false;
+
+        private readonly double mass0;        // initial mass (kg)
+        private readonly double thrust;       // constant thrust (N)
+        private readonly double burnTime;     // burn duration (s)
+        private readonly double CdA;          // drag coefficient*area (m^2)
+        private readonly double navConstant;  // PN constant (typically 3-5)
+        private readonly double maxAccel;     // max achievable accel (m/s^2)
+        private readonly double maxLifeTime;  // self destruct time
+
+        private double lifeTime = 0.0;
+
+        private const double rho = 1.225;     // air density (kg/m^3)
+        private const double g = 9.81;
+
+        private JPDA_Track targetTrack;
+
+        public Fox1Missile(Vector<double> startPos, JPDA_Track track,
+                           double navConstant = 4.0)
+        {
+            Pos = startPos.Clone();
+            Vel = DenseVector.OfArray(new double[] { 0, 0, 0 });
+            targetTrack = track;
+
+            mass0 = 200.0;     // kg
+            thrust = 20000.0;  // N
+            burnTime = 5.0;    // sec
+            CdA = 0.08;        // ~20 cm diameter
+            this.navConstant = navConstant;
+            maxAccel = 30.0 * g; // 30 g
+            maxLifeTime = 60.0;  // seconds
+        }
+
+        private static Vector<double> Cross(Vector<double> a, Vector<double> b)
+        {
+            return DenseVector.OfArray(new double[]
+            {
+                a[1]*b[2]-a[2]*b[1],
+                a[2]*b[0]-a[0]*b[2],
+                a[0]*b[1]-a[1]*b[0]
+            });
+        }
+
+        public void Update(double dt)
+        {
+            if (targetTrack == null) return;
+
+            Vector<double> targetPos = targetTrack.Filter.State.SubVector(0, 3);
+            Vector<double> targetVel = targetTrack.Filter.State.SubVector(3, 3);
+
+            Vector<double> r = targetPos - Pos;
+            Vector<double> vRel = targetVel - Vel;
+
+            double rNorm2 = Math.Max(r.Dot(r), 1e-6);
+            Vector<double> pnAccel = Cross(Vel, Cross(r, vRel)) * (navConstant / rNorm2);
+
+            if (pnAccel.L2Norm() > maxAccel)
+                pnAccel = pnAccel.Normalize(maxAccel);
+
+            double speed = Vel.L2Norm();
+            double mass = mass0; // no burn rate modelling
+            Vector<double> unitVel = speed > 1e-6 ? Vel / speed : DenseVector.OfArray(new double[]{0,0,1});
+
+            Vector<double> thrustAcc = (lifeTime < burnTime) ? (thrust / mass) * unitVel : DenseVector.Create(3, 0.0);
+            Vector<double> dragAcc = -0.5 * rho * speed * speed * CdA / mass * unitVel;
+            Vector<double> gravity = DenseVector.OfArray(new double[] { 0, 0, -g });
+
+            Vector<double> totalAcc = pnAccel + thrustAcc + dragAcc + gravity;
+
+            Vel += totalAcc * dt;
+            Pos += Vel * dt;
+            lifeTime += dt;
+
+            if (r.L2Norm() < 20.0)
+                HitTarget = true;
+        }
+    }
+}

--- a/RadarMain/Models/AdvancedRadar.cs
+++ b/RadarMain/Models/AdvancedRadar.cs
@@ -368,6 +368,8 @@ namespace RealRadarSim.Models
             }
         }
 
+        public JPDA_Track GetLockedTrack() => lockedTrack;
+
         public void UpdateTrackAssignments(List<JPDA_Track> tracks)
         {
             if (!UseAesaMode || LockBeam == null)


### PR DESCRIPTION
## Summary
- add Fox1Missile class with proportional navigation
- allow launching missiles from the simulation engine
- expose locked track from AdvancedRadar
- hook up `M` key in the radar UI to launch a missile and draw it
- mention missile controls in README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d07960a8832498ec3bca14bb33ee